### PR TITLE
Updated link to new Git repository in doc history.

### DIFF
--- a/src/docs/refdocs/langref/fblangref25/fblangref25-dochist.xml
+++ b/src/docs/refdocs/langref/fblangref25/fblangref25-dochist.xml
@@ -3,9 +3,9 @@
 "../../../../../tools/docbook-dtd/docbookx.dtd">
 <appendix id="fblangref25-dochist">
   <title>Document History</title>
-  <para>The exact file history is recorded in the <filename class="directory">manual</filename>
-  module in our CVS tree; see <ulink
-  url="http://sourceforge.net/cvs/?group_id=9028">http://sourceforge.net/cvs/?group_id=9028</ulink></para>
+  <para>The exact file history is recorded in the <filename class="directory">firebird-documentation</filename>
+  repository in our Git tree; see <ulink
+  url="https://github.com/FirebirdSQL/firebird-documentation/commits/master">https://github.com/FirebirdSQL/firebird-documentation/commits/master</ulink></para>
   <para><revhistory>
   
       <revision>


### PR DESCRIPTION
Since we moved the repository, we should adjust the paths. I think a link to the commits would be best.